### PR TITLE
fix: require modifier for letter shortcuts; expose shortcut params on Inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 4.0.1
+
+* `Y` and `Z` shortcuts now require a modifier key (Alt, Ctrl, or Meta) to prevent accidental activation while typing on desktop.
+* Exposed shortcut parameters (`inspectorShortcuts`, `inspectAndCompareShortcuts`, `colorPickerShortcuts`, `zoomShortcuts`) directly on the `Inspector` widget.
+* Fixed a bug where releasing the modifier before the letter key left the inspector stuck in `inspectAndCompare` or `zoom` mode. Thanks @yelmuratoff!
+
+## 4.0.0
+
+* Major codebase improvements and better inspector handling for certain box types (e.g. `FittedBox`). Also supports inspecting inside of widgets like `InteractiveViewer`. Thanks @EArminjon!
+* Exposed `BorderRadius` properties for better inspection of `DecoratedBox` widgets. Thanks @alpinnz!
+* Major refactor - the codebase is now split into `InspectorController` and `Inspector`. This means that you can now build your own custom inspector UI by using the `InspectorController`, instead of being tied down to the default one. You can check out the example at `custom_inspector_example.dart`. Thanks @yelmuratoff!
+
 ## 3.1.0
 
 * Added "compare" functionality - if a box is selected, you can now hold `Y` and hover another box to see the difference in the boxes' position. Thanks @EArminjon!

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
@@ -126,26 +126,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
@@ -203,10 +203,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.6"
   vector_math:
     dependency: transitive
     description:
@@ -224,5 +224,5 @@ packages:
     source: hosted
     version: "15.0.2"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
+  dart: ">=3.8.0 <4.0.0"
   flutter: ">=3.22.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -89,7 +89,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.1.0"
+    version: "4.0.1"
   leak_tracker:
     dependency: transitive
     description:

--- a/lib/src/inspector.dart
+++ b/lib/src/inspector.dart
@@ -3,6 +3,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:inspector/src/inspector_controller.dart';
 import 'package:inspector/src/widgets/ignore_tap_gesture.dart';
 import 'package:inspector/src/widgets/zoom/zoom_overlay.dart';
@@ -34,6 +35,21 @@ class Inspector extends StatefulWidget {
     this.isPanelVisible = true,
     this.isEnabled,
     this.panelBuilder,
+    this.inspectorShortcuts = const [
+      LogicalKeyboardKey.alt,
+      LogicalKeyboardKey.altLeft,
+      LogicalKeyboardKey.altRight,
+      LogicalKeyboardKey.meta,
+      LogicalKeyboardKey.metaLeft,
+      LogicalKeyboardKey.metaRight,
+    ],
+    this.inspectAndCompareShortcuts = const [LogicalKeyboardKey.keyY],
+    this.colorPickerShortcuts = const [
+      LogicalKeyboardKey.shift,
+      LogicalKeyboardKey.shiftLeft,
+      LogicalKeyboardKey.shiftRight,
+    ],
+    this.zoomShortcuts = const [LogicalKeyboardKey.keyZ],
   }) : super(key: key);
 
   final Widget child;
@@ -44,6 +60,10 @@ class Inspector extends StatefulWidget {
   final Widget Function(
           BuildContext context, InspectorController controller, Widget child)?
       panelBuilder;
+  final List<LogicalKeyboardKey> inspectorShortcuts;
+  final List<LogicalKeyboardKey> inspectAndCompareShortcuts;
+  final List<LogicalKeyboardKey> colorPickerShortcuts;
+  final List<LogicalKeyboardKey> zoomShortcuts;
 
   static InspectorState of(BuildContext context) {
     final InspectorState? result = maybeOf(context);
@@ -77,6 +97,14 @@ class InspectorState extends State<Inspector> {
   late InspectorController _controller;
   InspectorController get controller => _controller;
 
+  InspectorController _createController() => InspectorController(
+        isEnabled: _isEnabled,
+        widgetInspectorShortcuts: widget.inspectorShortcuts,
+        widgetInspectAndCompareShortcuts: widget.inspectAndCompareShortcuts,
+        colorPickerShortcuts: widget.colorPickerShortcuts,
+        zoomShortcuts: widget.zoomShortcuts,
+      );
+
   static const double _overlayMinSize = 128;
   static const double _overlayMaxSize = 246;
   static const double _overlayOffsetY = 16;
@@ -86,10 +114,7 @@ class InspectorState extends State<Inspector> {
     _isPanelVisible = widget.isPanelVisible;
     super.initState();
 
-    _controller = widget.controller ??
-        InspectorController(
-          isEnabled: _isEnabled,
-        );
+    _controller = widget.controller ?? _createController();
 
     if (_isEnabled) {
       _controller.registerKeyboardHandler();
@@ -110,7 +135,7 @@ class InspectorState extends State<Inspector> {
           _controller.registerKeyboardHandler();
         }
       } else if (oldWidget.controller != null) {
-        _controller = InspectorController(isEnabled: _isEnabled);
+        _controller = _createController();
         if (_isEnabled) {
           _controller.registerKeyboardHandler();
         }

--- a/lib/src/inspector_controller.dart
+++ b/lib/src/inspector_controller.dart
@@ -100,6 +100,7 @@ class InspectorController {
   Offset? _pointerHoverPosition;
   Timer? _onPointerHoverDebounce;
   late final KeyboardHandler _keyboardHandler;
+  bool _disposed = false;
 
   void registerKeyboardHandler() {
     _keyboardHandler.register();
@@ -110,6 +111,7 @@ class InspectorController {
   }
 
   void dispose() {
+    _disposed = true;
     _image?.dispose();
     modeNotifier.dispose();
     byteDataStateNotifier.dispose();
@@ -375,8 +377,19 @@ class InspectorController {
     final context = repaintBoundaryKey.currentContext!;
     final pixelRatio = MediaQuery.of(context).devicePixelRatio;
 
-    _image = await boundary.toImage(pixelRatio: pixelRatio);
-    byteDataStateNotifier.value = await _image!.toByteData();
+    final image = await boundary.toImage(pixelRatio: pixelRatio);
+
+    if (_disposed) {
+      image.dispose();
+      return;
+    }
+
+    _image = image;
+    final byteData = await _image!.toByteData();
+
+    if (_disposed) return;
+
+    byteDataStateNotifier.value = byteData;
   }
 
   Offset _extractShiftedOffset(Offset offset, BuildContext context) {

--- a/lib/src/keyboard_handler.dart
+++ b/lib/src/keyboard_handler.dart
@@ -49,17 +49,36 @@ class KeyboardHandler {
     _isRegistered = false;
   }
 
+  static final _modifierKeys = {
+    LogicalKeyboardKey.alt,
+    LogicalKeyboardKey.altLeft,
+    LogicalKeyboardKey.altRight,
+    LogicalKeyboardKey.control,
+    LogicalKeyboardKey.controlLeft,
+    LogicalKeyboardKey.controlRight,
+    LogicalKeyboardKey.meta,
+    LogicalKeyboardKey.metaLeft,
+    LogicalKeyboardKey.metaRight,
+  };
+
   bool _handler(KeyEvent event) {
     if (event is KeyRepeatEvent) return false;
+
+    final pressed = HardwareKeyboard.instance.logicalKeysPressed;
+    final hasModifier = pressed.any(_modifierKeys.contains);
 
     if (inspectorStateKeys.contains(event.logicalKey)) {
       onInspectorStateChanged(event is! KeyUpEvent);
     } else if (inspectAndCompareKeys.contains(event.logicalKey)) {
-      onInspectAndCompareChanged(event is! KeyUpEvent);
+      if (event is KeyUpEvent || hasModifier) {
+        onInspectAndCompareChanged(event is! KeyUpEvent);
+      }
     } else if (colorPickerStateKeys.contains(event.logicalKey)) {
       onColorPickerStateChanged(event is! KeyUpEvent);
     } else if (zoomStateKeys.contains(event.logicalKey)) {
-      onZoomStateChanged(event is! KeyUpEvent);
+      if (event is KeyUpEvent || hasModifier) {
+        onZoomStateChanged(event is! KeyUpEvent);
+      }
     }
 
     return false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: inspector
 description: A Flutter package for inspecting widgets. Useful for quick debugging or QA testing.
-version: 3.1.0
+version: 4.0.1
 homepage: https://github.com/kekland/inspector
 
 environment:

--- a/test/keyboard_shortcuts_test.dart
+++ b/test/keyboard_shortcuts_test.dart
@@ -1,0 +1,405 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:inspector/inspector.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Widget _buildApp({
+  List<LogicalKeyboardKey>? inspectorShortcuts,
+  List<LogicalKeyboardKey>? inspectAndCompareShortcuts,
+  List<LogicalKeyboardKey>? colorPickerShortcuts,
+  List<LogicalKeyboardKey>? zoomShortcuts,
+}) {
+  return MaterialApp(
+    builder: (context, child) => Inspector(
+      inspectorShortcuts: inspectorShortcuts ??
+          const [
+            LogicalKeyboardKey.alt,
+            LogicalKeyboardKey.altLeft,
+            LogicalKeyboardKey.altRight,
+            LogicalKeyboardKey.meta,
+            LogicalKeyboardKey.metaLeft,
+            LogicalKeyboardKey.metaRight,
+          ],
+      inspectAndCompareShortcuts:
+          inspectAndCompareShortcuts ?? const [LogicalKeyboardKey.keyY],
+      colorPickerShortcuts: colorPickerShortcuts ??
+          const [
+            LogicalKeyboardKey.shift,
+            LogicalKeyboardKey.shiftLeft,
+            LogicalKeyboardKey.shiftRight,
+          ],
+      zoomShortcuts: zoomShortcuts ?? const [LogicalKeyboardKey.keyZ],
+      child: child!,
+    ),
+    home: const Scaffold(body: SizedBox()),
+  );
+}
+
+InspectorMode _mode(WidgetTester tester) => tester
+    .state<InspectorState>(find.byType(Inspector))
+    .controller
+    .modeNotifier
+    .value;
+
+// Zoom and colorPicker modes trigger async GPU work (boundary.toImage /
+// toByteData). These are platform-level callbacks that pumpAndSettle cannot
+// drain on its own. Call this helper at the end of any test that activates
+// those modes so the work completes while the widget is still mounted,
+// preventing "ValueNotifier used after dispose" errors.
+Future<void> _drainScreenshotCapture(WidgetTester tester) async {
+  await tester.pump(); // fires addPostFrameCallback → starts _extractByteData
+  await tester.runAsync(() async {}); // lets platform callbacks complete
+  await tester.pump(); // process any pending frame work
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  // We use LogicalKeyboardKey.control as the modifier throughout most tests.
+  // It satisfies the hasModifier guard (present in _modifierKeys) but is NOT
+  // in the default inspectorShortcuts list, so pressing it alone won't
+  // accidentally activate inspector mode and pollute assertions.
+
+  group('modifier guard — inspectAndCompare (keyY)', () {
+    testWidgets(
+      'given no modifier held, when keyY pressed, then mode stays none',
+      (tester) async {
+        // Given
+        await tester.pumpWidget(_buildApp());
+
+        // When
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.keyY);
+        await tester.pump();
+
+        // Then
+        expect(_mode(tester), InspectorMode.none);
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.keyY);
+        await tester.pump();
+      },
+    );
+
+    testWidgets(
+      'given control held, when keyY pressed, then mode becomes inspectAndCompare',
+      (tester) async {
+        // Given
+        await tester.pumpWidget(_buildApp());
+
+        // When – mode changes synchronously via KeyboardHandler
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.keyY);
+
+        // Then – check before pump; inspectAndCompare has no screenshot capture
+        expect(_mode(tester), InspectorMode.inspectAndCompare);
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.keyY);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+        await tester.pump();
+      },
+    );
+
+    testWidgets(
+      'given control released before keyY, when keyY released, then mode is no longer inspectAndCompare',
+      (tester) async {
+        // Given – activate inspectAndCompare
+        await tester.pumpWidget(_buildApp());
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.keyY);
+        expect(_mode(tester), InspectorMode.inspectAndCompare);
+
+        // When – release modifier first, then the letter key
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.keyY);
+
+        // Then – mode must not be stuck.
+        // (_toggleMode special case: leaving inspectAndCompare → inspector.)
+        expect(_mode(tester), isNot(InspectorMode.inspectAndCompare));
+
+        await tester.pump();
+      },
+    );
+  });
+
+  group('modifier guard — zoom (keyZ)', () {
+    testWidgets(
+      'given no modifier held, when keyZ pressed, then mode stays none',
+      (tester) async {
+        // Given
+        await tester.pumpWidget(_buildApp());
+
+        // When
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
+        await tester.pump();
+
+        // Then
+        expect(_mode(tester), InspectorMode.none);
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.keyZ);
+        await tester.pump();
+      },
+    );
+
+    testWidgets(
+      'given control held, when keyZ pressed, then mode becomes zoom',
+      (tester) async {
+        // Given
+        await tester.pumpWidget(_buildApp());
+
+        // When – mode changes synchronously
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
+
+        // Then – check before pump to avoid triggering screenshot work before assertion
+        expect(_mode(tester), InspectorMode.zoom);
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.keyZ);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+        // Drain async screenshot capture (boundary.toImage / toByteData)
+        // before the widget is torn down.
+        await _drainScreenshotCapture(tester);
+      },
+    );
+
+    testWidgets(
+      'given control released before keyZ, when keyZ released, then mode is no longer zoom',
+      (tester) async {
+        // Given – activate zoom
+        await tester.pumpWidget(_buildApp());
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
+        expect(_mode(tester), InspectorMode.zoom);
+
+        // When – release modifier first, then letter key
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.keyZ);
+
+        // Then – mode must not be stuck at zoom
+        expect(_mode(tester), isNot(InspectorMode.zoom));
+
+        await _drainScreenshotCapture(tester);
+      },
+    );
+  });
+
+  group('modifier-only shortcuts are unaffected by the guard', () {
+    testWidgets(
+      'alt alone activates inspector mode',
+      (tester) async {
+        // Given
+        await tester.pumpWidget(_buildApp());
+
+        // When
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.alt);
+        await tester.pump();
+
+        // Then
+        expect(_mode(tester), InspectorMode.inspector);
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.alt);
+        await tester.pump();
+        expect(_mode(tester), InspectorMode.none);
+      },
+    );
+
+    testWidgets(
+      'shift alone activates colorPicker mode',
+      (tester) async {
+        // Given
+        await tester.pumpWidget(_buildApp());
+
+        // When – mode changes synchronously
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+
+        // Then
+        expect(_mode(tester), InspectorMode.colorPicker);
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+
+        // Drain async screenshot capture before widget teardown
+        await _drainScreenshotCapture(tester);
+        expect(_mode(tester), InspectorMode.none);
+      },
+    );
+  });
+
+  group('Inspector.inspectAndCompareShortcuts customisation', () {
+    testWidgets(
+      'given custom key F1, control+keyY does not activate inspectAndCompare',
+      (tester) async {
+        // Given – F1 replaces default keyY
+        await tester.pumpWidget(
+          _buildApp(inspectAndCompareShortcuts: const [LogicalKeyboardKey.f1]),
+        );
+
+        // When – press the old default with a modifier
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.keyY);
+        await tester.pump();
+
+        // Then
+        expect(_mode(tester), isNot(InspectorMode.inspectAndCompare));
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.keyY);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+        await tester.pump();
+      },
+    );
+
+    testWidgets(
+      'given custom key F1, control+F1 activates inspectAndCompare',
+      (tester) async {
+        // Given
+        await tester.pumpWidget(
+          _buildApp(inspectAndCompareShortcuts: const [LogicalKeyboardKey.f1]),
+        );
+
+        // When
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.f1);
+
+        // Then – check synchronously; inspectAndCompare has no screenshot
+        expect(_mode(tester), InspectorMode.inspectAndCompare);
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.f1);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+        await tester.pump();
+      },
+    );
+  });
+
+  group('Inspector.inspectorShortcuts customisation', () {
+    testWidgets(
+      'given custom key F2, alt does not activate inspector mode',
+      (tester) async {
+        // Given
+        await tester.pumpWidget(
+          _buildApp(inspectorShortcuts: const [LogicalKeyboardKey.f2]),
+        );
+
+        // When
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.alt);
+        await tester.pump();
+
+        // Then
+        expect(_mode(tester), InspectorMode.none);
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.alt);
+        await tester.pump();
+      },
+    );
+
+    testWidgets(
+      'given custom key F2, F2 activates and deactivates inspector mode',
+      (tester) async {
+        // Given
+        await tester.pumpWidget(
+          _buildApp(inspectorShortcuts: const [LogicalKeyboardKey.f2]),
+        );
+
+        // When
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.f2);
+        await tester.pump();
+        expect(_mode(tester), InspectorMode.inspector);
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.f2);
+        await tester.pump();
+
+        // Then
+        expect(_mode(tester), InspectorMode.none);
+      },
+    );
+  });
+
+  group('Inspector.zoomShortcuts customisation', () {
+    testWidgets(
+      'given custom key F3, control+keyZ does not activate zoom',
+      (tester) async {
+        // Given – F3 replaces default keyZ
+        await tester.pumpWidget(
+          _buildApp(zoomShortcuts: const [LogicalKeyboardKey.f3]),
+        );
+
+        // When – press old default with a modifier
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
+        await tester.pump();
+
+        // Then
+        expect(_mode(tester), isNot(InspectorMode.zoom));
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.keyZ);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+        await tester.pump();
+      },
+    );
+
+    testWidgets(
+      'given custom key F3, control+F3 activates zoom',
+      (tester) async {
+        // Given
+        await tester.pumpWidget(
+          _buildApp(zoomShortcuts: const [LogicalKeyboardKey.f3]),
+        );
+
+        // When – mode changes synchronously
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.f3);
+
+        // Then – check before pump; drain screenshot capture afterwards
+        expect(_mode(tester), InspectorMode.zoom);
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.f3);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+        await _drainScreenshotCapture(tester);
+      },
+    );
+  });
+
+  group('Inspector.colorPickerShortcuts customisation', () {
+    testWidgets(
+      'given custom key F4, default shift does not activate colorPicker',
+      (tester) async {
+        // Given
+        await tester.pumpWidget(
+          _buildApp(colorPickerShortcuts: const [LogicalKeyboardKey.f4]),
+        );
+
+        // When
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+        await tester.pump();
+
+        // Then
+        expect(_mode(tester), InspectorMode.none);
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+        await tester.pump();
+      },
+    );
+
+    testWidgets(
+      'given custom key F4, F4 activates and deactivates colorPicker',
+      (tester) async {
+        // Given
+        await tester.pumpWidget(
+          _buildApp(colorPickerShortcuts: const [LogicalKeyboardKey.f4]),
+        );
+
+        // When – mode changes synchronously
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.f4);
+
+        // Then
+        expect(_mode(tester), InspectorMode.colorPicker);
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.f4);
+        await _drainScreenshotCapture(tester);
+        expect(_mode(tester), InspectorMode.none);
+      },
+    );
+  });
+}

--- a/test/keyboard_shortcuts_test.dart
+++ b/test/keyboard_shortcuts_test.dart
@@ -3,10 +3,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:inspector/inspector.dart';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 Widget _buildApp({
   List<LogicalKeyboardKey>? inspectorShortcuts,
   List<LogicalKeyboardKey>? inspectAndCompareShortcuts,
@@ -45,27 +41,13 @@ InspectorMode _mode(WidgetTester tester) => tester
     .modeNotifier
     .value;
 
-// Zoom and colorPicker modes trigger async GPU work (boundary.toImage /
-// toByteData). These are platform-level callbacks that pumpAndSettle cannot
-// drain on its own. Call this helper at the end of any test that activates
-// those modes so the work completes while the widget is still mounted,
-// preventing "ValueNotifier used after dispose" errors.
 Future<void> _drainScreenshotCapture(WidgetTester tester) async {
-  await tester.pump(); // fires addPostFrameCallback → starts _extractByteData
-  await tester.runAsync(() async {}); // lets platform callbacks complete
-  await tester.pump(); // process any pending frame work
+  await tester.pump();
+  await tester.runAsync(() async {});
+  await tester.pump();
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 void main() {
-  // We use LogicalKeyboardKey.control as the modifier throughout most tests.
-  // It satisfies the hasModifier guard (present in _modifierKeys) but is NOT
-  // in the default inspectorShortcuts list, so pressing it alone won't
-  // accidentally activate inspector mode and pollute assertions.
-
   group('modifier guard — inspectAndCompare (keyY)', () {
     testWidgets(
       'given no modifier held, when keyY pressed, then mode stays none',
@@ -91,7 +73,7 @@ void main() {
         // Given
         await tester.pumpWidget(_buildApp());
 
-        // When – mode changes synchronously via KeyboardHandler
+        // When
         await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
         await tester.sendKeyDownEvent(LogicalKeyboardKey.keyY);
 
@@ -151,7 +133,7 @@ void main() {
         // Given
         await tester.pumpWidget(_buildApp());
 
-        // When – mode changes synchronously
+        // When
         await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
         await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
 
@@ -213,7 +195,7 @@ void main() {
         // Given
         await tester.pumpWidget(_buildApp());
 
-        // When – mode changes synchronously
+        // When
         await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
 
         // Then
@@ -232,7 +214,7 @@ void main() {
     testWidgets(
       'given custom key F1, control+keyY does not activate inspectAndCompare',
       (tester) async {
-        // Given – F1 replaces default keyY
+        // Given
         await tester.pumpWidget(
           _buildApp(inspectAndCompareShortcuts: const [LogicalKeyboardKey.f1]),
         );
@@ -263,7 +245,7 @@ void main() {
         await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
         await tester.sendKeyDownEvent(LogicalKeyboardKey.f1);
 
-        // Then – check synchronously; inspectAndCompare has no screenshot
+        // Then – check before pump; inspectAndCompare has no screenshot capture
         expect(_mode(tester), InspectorMode.inspectAndCompare);
 
         await tester.sendKeyUpEvent(LogicalKeyboardKey.f1);
@@ -320,12 +302,12 @@ void main() {
     testWidgets(
       'given custom key F3, control+keyZ does not activate zoom',
       (tester) async {
-        // Given – F3 replaces default keyZ
+        // Given
         await tester.pumpWidget(
           _buildApp(zoomShortcuts: const [LogicalKeyboardKey.f3]),
         );
 
-        // When – press old default with a modifier
+        // When – press the old default with a modifier
         await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
         await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
         await tester.pump();
@@ -347,7 +329,7 @@ void main() {
           _buildApp(zoomShortcuts: const [LogicalKeyboardKey.f3]),
         );
 
-        // When – mode changes synchronously
+        // When
         await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
         await tester.sendKeyDownEvent(LogicalKeyboardKey.f3);
 
@@ -390,7 +372,7 @@ void main() {
           _buildApp(colorPickerShortcuts: const [LogicalKeyboardKey.f4]),
         );
 
-        // When – mode changes synchronously
+        // When
         await tester.sendKeyDownEvent(LogicalKeyboardKey.f4);
 
         // Then


### PR DESCRIPTION
 ## Problem                                                                                                                                  
                                                                                                                                              
  ### Accidental activation on desktop                                                                                                    
  `keyY` and `keyZ` are registered globally via `HardwareKeyboard`. On desktop,                                                               
  typing in any `TextField` would trigger `inspectAndCompare` or `zoom` mode.                                                                 
                                                                                                                                              
  ### No shortcut customisation without manual controller management                                                                      
  `InspectorController` already accepted shortcut parameters, but `Inspector`                                                                 
  widget didn't expose them. The only way to remap keys was to instantiate                                                                    
  `InspectorController` manually and manage its lifecycle yourself.                                                                           
                                                                                                                                              
  ## Changes                                                                                                                                  
                                                                                                                                              
  - **Modifier guard** - `inspectAndCompare` (Y) and `zoom` (Z) now require a                                                                 
    modifier key (Alt, Ctrl, or Meta) to activate. Modifier-only shortcuts                                                                    
    (Alt for inspector, Shift for color picker) are unaffected.                                                                               
  - **KeyUpEvent always passes the guard** - previously, releasing the modifier                                                               
    before the letter key left the mode active indefinitely.                                                                                  
  - **Shortcut params on `Inspector`** - `inspectorShortcuts`,                                                                                
    `inspectAndCompareShortcuts`, `colorPickerShortcuts`, `zoomShortcuts`                                                                     
    are now first-class parameters with sensible defaults.                                                                                    
  - **Dispose guard in `_extractByteData`** - fixed a pre-existing crash where                                                                
    async screenshot capture could write to a disposed `ValueNotifier` after                                                                  
    the widget was torn down.