### PR TITLE
fix: exclude invisible render objects from hit-test traversal

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -27,10 +27,18 @@ class InspectorUtils {
     RenderObject renderObject,
     Offset globalOffset,
   ) sync* {
-    if (renderObject is RenderBox) {
-      final local = renderObject.globalToLocal(globalOffset);
+    if (renderObject is RenderBox && renderObject.hasSize) {
+      // Test containment in global space. globalToLocal + local bounds
+      // falsely matches any render object with a singular transform
+      // (e.g. NavigationBar's hidden tab indicator at opacity 0).
+      final globalRect = MatrixUtils.transformRect(
+        renderObject.getTransformTo(null),
+        Offset.zero & renderObject.size,
+      );
 
-      if ((Offset.zero & renderObject.size).contains(local)) {
+      if (globalRect.isFinite &&
+          !globalRect.isEmpty &&
+          globalRect.contains(globalOffset)) {
         yield renderObject;
       }
     }


### PR DESCRIPTION
Fix for #26 