### PR TITLE
fix: Improve hit test precision

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -27,12 +27,20 @@ class InspectorUtils {
     RenderObject renderObject,
     Offset globalOffset,
   ) sync* {
-    if (renderObject is RenderBox) {
-      final local = renderObject.globalToLocal(globalOffset);
+    if (renderObject is RenderBox && renderObject.hasSize) {
+      final globalRect = MatrixUtils.transformRect(
+        renderObject.getTransformTo(null),
+        Offset.zero & renderObject.size,
+      );
 
-      if ((Offset.zero & renderObject.size).contains(local)) {
-        yield renderObject;
-      }
+      // Skip non-visible render objects (e.g. empty bounds or invalid transforms).
+      // Also prune subtrees whose global bounds do not contain the target point,
+      // since their descendants cannot intersect it under normal non-overflowing
+      // layouts.
+      if (!globalRect.isFinite || globalRect.isEmpty) return;
+      if (!globalRect.contains(globalOffset)) return;
+
+      yield renderObject;
     }
 
     final children = <RenderObject>[];

--- a/lib/src/widgets/components/box_info_panel_widget.dart
+++ b/lib/src/widgets/components/box_info_panel_widget.dart
@@ -162,91 +162,45 @@ class BoxInfoPanelWidget extends StatelessWidget {
     return '${f(resolved.topLeft.x)}, ${f(resolved.topRight.x)}, ${f(resolved.bottomRight.x)}, ${f(resolved.bottomLeft.x)}';
   }
 
-  RenderDecoratedBox? _findSelectedDecoratedBox() {
-    final target = boxInfo.targetRenderBox;
-    return target is RenderDecoratedBox ? target : null;
+  BorderRadiusGeometry? _extractBorderRadiusFromShape(ShapeBorder shape) {
+    if (shape is RoundedRectangleBorder) return shape.borderRadius;
+    if (shape is ContinuousRectangleBorder) return shape.borderRadius;
+    if (shape is BeveledRectangleBorder) return shape.borderRadius;
+    return null;
   }
 
-  RenderDecoratedBox? _findNearestDecoratedBoxFromHitTestPath() {
-    // When tapping a Container, the selected RenderBox might be a child
-    // (e.g. alignment/padding) instead of the RenderDecoratedBox itself.
-    // Use the hitTestPath to locate the nearest decorated box in the same
-    // subtree under the pointer.
-    for (final box in boxInfo.hitTestPath) {
-      if (box.size != boxInfo.targetRect.size) return null;
-      if (box is RenderDecoratedBox) return box;
+  BorderRadiusGeometry? _getDecorationBorderRadius(Decoration decoration) {
+    if (decoration is BoxDecoration) return decoration.borderRadius;
+    if (decoration is ShapeDecoration) {
+      return _extractBorderRadiusFromShape(decoration.shape);
     }
     return null;
   }
 
-  RenderDecoratedBox? _findChildDecoratedBoxFromTarget() {
-    final target = boxInfo.targetRenderBox;
-    if (target is RenderProxyBoxMixin) {
-      final child = target.child;
-      if (child != null &&
-          child.size == target.size &&
-          child is RenderDecoratedBox) {
-        return child;
-      }
-    }
+  Color? _getDecorationColor(Decoration decoration) {
+    if (decoration is BoxDecoration) return decoration.color;
+    if (decoration is ShapeDecoration) return decoration.color;
     return null;
   }
 
-  RenderDecoratedBox? _findDecoratedBoxForDisplay() {
-    // Prefer the selected render object when it is decorated; otherwise, fall
-    // back to the nearest decorated box under the pointer.
-    return _findSelectedDecoratedBox() ??
-        _findNearestDecoratedBoxFromHitTestPath() ??
-        _findChildDecoratedBoxFromTarget();
-  }
-
-  bool _hasSelectedDecoratedInfo() {
-    // Selection-first policy: never show decoration info when the selected box
-    // is a RenderParagraph (text selection should focus on text).
-    if (boxInfo.targetRenderBox is RenderParagraph) return false;
-
-    final decorated = _findDecoratedBoxForDisplay();
-    if (decorated == null) return false;
-
-    final d = decorated.decoration;
-    if (d is! BoxDecoration) return false;
-
-    return d.color != null ||
-        d.borderRadius != null ||
-        d.shape != BoxShape.rectangle ||
-        d.border != null ||
-        d.boxShadow != null ||
-        d.gradient != null;
-  }
-
-  Widget _buildRenderDecoratedBoxInfo(BuildContext context) {
+  Widget _buildDecorationInfoRows(
+    BuildContext context, {
+    BorderRadiusGeometry? borderRadius,
+    Color? color,
+  }) {
     final theme = Theme.of(context);
-
-    final renderDecoratedBox = _findDecoratedBoxForDisplay();
-    if (renderDecoratedBox == null) return const SizedBox.shrink();
-
-    final decoration = renderDecoratedBox.decoration;
-    if (decoration is! BoxDecoration) return const SizedBox.shrink();
 
     return Wrap(
       spacing: 12.0,
       runSpacing: 8.0,
       children: [
-        if (decoration.borderRadius != null)
+        if (borderRadius != null)
           _buildInfoRow(
             context,
             icon: Icons.rounded_corner,
             subtitle: 'border radius (LTRB)',
             backgroundColor: theme.chipTheme.backgroundColor,
-            child: Text(_formatBorderRadiusLTRB(decoration.borderRadius!)),
-          ),
-        if (decoration.shape != BoxShape.rectangle)
-          _buildInfoRow(
-            context,
-            icon: Icons.circle_outlined,
-            subtitle: 'shape',
-            backgroundColor: theme.chipTheme.backgroundColor,
-            child: Text(decoration.shape.toString()),
+            child: Text(_formatBorderRadiusLTRB(borderRadius)),
           ),
         _buildInfoRow(
           context,
@@ -254,12 +208,122 @@ class BoxInfoPanelWidget extends StatelessWidget {
           subtitle: 'color',
           backgroundColor: theme.chipTheme.backgroundColor,
           child: Text(
-            decoration.color != null
-                ? '#${colorToHexString(decoration.color!, withAlpha: true)}'
+            color != null
+                ? '#${colorToHexString(color, withAlpha: true)}'
                 : 'n/a',
           ),
         ),
       ],
+    );
+  }
+
+  RenderDecoratedBox? _findSelectedDecoratedBox() {
+    final target = boxInfo.targetRenderBox;
+    return target is RenderDecoratedBox ? target : null;
+  }
+
+  RenderDecoratedBox? _findParentDecoratedBox() {
+    // Try to find a RenderDecoratedBox parent by walking up the render tree
+    var current = boxInfo.targetRenderBox.parent;
+    while (current != null) {
+      if (current is RenderDecoratedBox) {
+        return current;
+      }
+      current = current.parent;
+      // Safety limit to avoid infinite loops
+      if (current is RenderView) break;
+    }
+    return null;
+  }
+
+  RenderDecoratedBox? _findNearestDecoratedBoxFromHitTestPath() {
+    // When tapping a Container, the selected RenderBox might be a child
+    // (e.g. alignment/padding) instead of the RenderDecoratedBox itself.
+    // Use the hitTestPath to locate the first decorated box found.
+    for (final box in boxInfo.hitTestPath) {
+      if (box is RenderDecoratedBox) return box;
+    }
+    return null;
+  }
+
+  RenderDecoratedBox? _findChildDecoratedBoxFromTarget() {
+    final target = boxInfo.targetRenderBox;
+
+    // Recursive helper to walk the render tree
+    RenderDecoratedBox? findDecoratedInSubtree(RenderBox? box) {
+      if (box == null) return null;
+      if (box is RenderDecoratedBox) return box;
+      if (box is RenderProxyBoxMixin) {
+        return findDecoratedInSubtree(box.child);
+      }
+      return null;
+    }
+
+    // If target is already decorated, return it
+    if (target is RenderDecoratedBox) return target;
+
+    // Otherwise, search in children
+    if (target is RenderProxyBoxMixin) {
+      return findDecoratedInSubtree(target.child);
+    }
+
+    return null;
+  }
+
+  RenderDecoratedBox? _findDecoratedBoxForDisplay() {
+    // Prefer the selected render object when it is decorated; otherwise, fall
+    // back to nearest decorated box in various locations: parents, hitTestPath, or children.
+    return _findSelectedDecoratedBox() ??
+        _findParentDecoratedBox() ??
+        _findNearestDecoratedBoxFromHitTestPath() ??
+        _findChildDecoratedBoxFromTarget();
+  }
+
+  bool _hasSelectedDecoratedInfo(RenderDecoratedBox? decorated) {
+    // Selection-first policy: never show decoration info when the selected box
+    // is a RenderParagraph (text selection should focus on text).
+    if (boxInfo.targetRenderBox is RenderParagraph) return false;
+
+    if (decorated == null) return false;
+
+    final d = decorated.decoration;
+
+    if (d is BoxDecoration) {
+      return d.color != null ||
+          d.borderRadius != null ||
+          d.shape != BoxShape.rectangle ||
+          d.border != null ||
+          d.boxShadow != null ||
+          d.gradient != null;
+    }
+
+    if (d is ShapeDecoration) {
+      return d.color != null ||
+          d.image != null ||
+          d.gradient != null ||
+          (d.shadows?.isNotEmpty ?? false) ||
+          d.shape != const RoundedRectangleBorder() ||
+          _getDecorationBorderRadius(d) != null;
+    }
+
+    return false;
+  }
+
+  Widget _buildRenderDecoratedBoxInfo(
+    BuildContext context,
+    RenderDecoratedBox? renderDecoratedBox,
+  ) {
+    if (renderDecoratedBox == null) return const SizedBox.shrink();
+
+    final decoration = renderDecoratedBox.decoration;
+    if (decoration is! BoxDecoration && decoration is! ShapeDecoration) {
+      return const SizedBox.shrink();
+    }
+
+    return _buildDecorationInfoRows(
+      context,
+      borderRadius: _getDecorationBorderRadius(decoration),
+      color: _getDecorationColor(decoration),
     );
   }
 
@@ -367,8 +431,10 @@ class BoxInfoPanelWidget extends StatelessWidget {
 
     final target = boxInfo.targetRenderBox;
     final isSelectedParagraph = target is RenderParagraph;
+    final decoratedBox =
+        !isSelectedParagraph ? _findDecoratedBoxForDisplay() : null;
     final hasSelectedDecoration =
-        !isSelectedParagraph && _hasSelectedDecoratedInfo();
+        decoratedBox != null && _hasSelectedDecoratedInfo(decoratedBox);
 
     return Card(
       child: SizedBox(
@@ -425,7 +491,7 @@ class BoxInfoPanelWidget extends StatelessWidget {
                   height: 16.0,
                   color: theme.dividerColor,
                 ),
-                _buildRenderDecoratedBoxInfo(context),
+                _buildRenderDecoratedBoxInfo(context, decoratedBox),
               ],
             ],
           ),

--- a/lib/src/widgets/components/box_info_panel_widget.dart
+++ b/lib/src/widgets/components/box_info_panel_widget.dart
@@ -280,9 +280,8 @@ class BoxInfoPanelWidget extends StatelessWidget {
   }
 
   bool _hasSelectedDecoratedInfo(RenderDecoratedBox? decorated) {
-    // Selection-first policy: never show decoration info when the selected box
-    // is a RenderParagraph (text selection should focus on text).
-    if (boxInfo.targetRenderBox is RenderParagraph) return false;
+    if (boxInfo.targetRenderBox is RenderParagraph ||
+        _findRenderEditable(boxInfo.targetRenderBox) != null) return false;
 
     if (decorated == null) return false;
 
@@ -346,13 +345,33 @@ class BoxInfoPanelWidget extends StatelessWidget {
     return styles;
   }
 
+  /// Walks up the render tree to find the nearest [RenderEditable] ancestor.
+  /// Use case: when inspecting a SelectableText, we need to find the RenderEditable to access the text and styles.
+  RenderEditable? _findRenderEditable(RenderBox current) {
+    if (current is RenderEditable) return current;
+    var parent = current.parent;
+    while (parent != null) {
+      if (parent is RenderEditable) return parent;
+      if (parent is RenderView) break;
+      parent = parent.parent;
+    }
+    return null;
+  }
+
   Widget _buildRenderParagraphInfo(BuildContext context) {
     final theme = Theme.of(context);
 
     final target = boxInfo.targetRenderBox;
-    if (target is! RenderParagraph) return const SizedBox.shrink();
 
-    final styles = _extractTextStyles(target.text);
+    InlineSpan? span;
+    if (target is RenderParagraph) {
+      span = target.text;
+    } else {
+      span = _findRenderEditable(target)?.text;
+    }
+    if (span == null) return const SizedBox.shrink();
+
+    final styles = _extractTextStyles(span);
 
     if (styles.isEmpty) return const SizedBox.shrink();
 
@@ -430,7 +449,9 @@ class BoxInfoPanelWidget extends StatelessWidget {
     final theme = Theme.of(context);
 
     final target = boxInfo.targetRenderBox;
-    final isSelectedParagraph = target is RenderParagraph;
+
+    final isSelectedParagraph =
+        target is RenderParagraph || _findRenderEditable(target) != null;
     final decoratedBox =
         !isSelectedParagraph ? _findDecoratedBoxForDisplay() : null;
     final hasSelectedDecoration =

--- a/lib/src/widgets/inspector/box_info.dart
+++ b/lib/src/widgets/inspector/box_info.dart
@@ -20,15 +20,23 @@ class BoxInfo {
   }) {
     final hitTestPath = List<RenderBox>.unmodifiable(boxes);
 
-    RenderBox targetRenderBox = boxes.first;
+    /// Best-match strategy combining two criteria:
+    ///   1. Smallest area  → most visually precise box under the pointer.
+    ///   2. Deepest in tree as tiebreaker for equal-area boxes:
+    ///      - If [box] is a descendant of [best] (parent-child), prefer [box]
+    ///        (more specific child wins over its wrapper).
+    ///      - If they are siblings (e.g. two Stack children of same size),
+    ///        prefer [best], which arrived first because [_collectAt] reverses
+    ///        children → foreground (topmost Z-order) is emitted before
+    ///        background, so keeping [best] preserves the correct Stack order.
+    RenderBox targetRenderBox = boxes.reduce((best, box) {
+      final bestArea = best.size.width * best.size.height;
+      final boxArea = box.size.width * box.size.height;
+      if (boxArea < bestArea) return box;
+      if (boxArea == bestArea && box.isDescendantOf(best)) return box;
+      return best;
+    });
     RenderBox? containerRenderBox;
-
-    /// Used [isSmallerThan] to find the smallest box under the cursor
-    for (final box in boxes) {
-      if (box.size.isSmallerThan(targetRenderBox.size)) {
-        targetRenderBox = box;
-      }
-    }
 
     if (findContainer) {
       /// The >= is used to check whether the item is fully contained by the other box.
@@ -76,9 +84,10 @@ class BoxInfo {
   EdgeInsets _calculateOriginalPadding() {
     if (containerRenderBox == null) return EdgeInsets.zero;
 
-    // Get the target's position relative to the container
-    final targetOffset = targetRenderBox.localToGlobal(Offset.zero);
-    final containerOffset = containerRenderBox!.localToGlobal(Offset.zero);
+    // Use targetRect.topLeft (center-based, rotation-invariant) instead of
+    // localToGlobal(Offset.zero) which rotates every frame inside Transform.rotate.
+    final targetTopLeft = targetRect.topLeft;
+    final containerTopLeft = containerRect!.topLeft;
 
     // Calculate scale factor from the transformation
     final scaledTargetSize = targetRect.size;
@@ -88,8 +97,8 @@ class BoxInfo {
         : 1.0;
 
     // Calculate padding in original coordinates
-    final left = (targetOffset.dx - containerOffset.dx) / scale;
-    final top = (targetOffset.dy - containerOffset.dy) / scale;
+    final left = (targetTopLeft.dx - containerTopLeft.dx) / scale;
+    final top = (targetTopLeft.dy - containerTopLeft.dy) / scale;
     final right =
         containerRenderBox!.size.width - originalTargetSize.width - left;
     final bottom =
@@ -167,12 +176,27 @@ class BoxInfo {
 Rect? getRectFromRenderBox(RenderBox renderBox) {
   if (!renderBox.attached) return null;
 
-  final topLeft = renderBox.localToGlobal(Offset.zero);
-  final bottomRight = renderBox.localToGlobal(
-    Offset(renderBox.size.width, renderBox.size.height),
+  // Anchor on the center instead of corners: the center is invariant under
+  // Transform.rotate, keeping the overlay rect stable during animations.
+  // Half-dimensions are measured as center-to-edge distances so that
+  // Transform.scale is still reflected in the visual rect size.
+  final center = renderBox.localToGlobal(renderBox.size.center(Offset.zero));
+
+  final rightCenter = renderBox.localToGlobal(
+    Offset(renderBox.size.width, renderBox.size.height / 2),
+  );
+  final bottomCenter = renderBox.localToGlobal(
+    Offset(renderBox.size.width / 2, renderBox.size.height),
   );
 
-  return Rect.fromPoints(topLeft, bottomRight);
+  final halfWidth = (rightCenter - center).distance;
+  final halfHeight = (bottomCenter - center).distance;
+
+  return Rect.fromCenter(
+    center: center,
+    width: halfWidth * 2,
+    height: halfHeight * 2,
+  );
 }
 
 double calculateBoxPosition({

--- a/test/inspector_test.dart
+++ b/test/inspector_test.dart
@@ -209,7 +209,7 @@ void main() {
       await tester.tapAt(position);
       await tester.pump();
 
-      expect(find.textContaining('RenderConstrainedBox'), findsOneWidget);
+      expect(find.textContaining('RenderPadding'), findsOneWidget);
       expect(find.text('100.0 × 100.0'), findsWidgets);
       expect(find.text('50.0, 150.0, 50.0, 150.0'), findsOneWidget);
     });

--- a/test/src/widgets/components/box_info_panel_widget_test.dart
+++ b/test/src/widgets/components/box_info_panel_widget_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:inspector/inspector.dart';
+
+const _widgetKey = ValueKey('widget');
+
+void main() {
+  Widget _buildApp(Widget body) {
+    return MaterialApp(
+      builder: (context, child) => Inspector(child: child!),
+      home: Scaffold(body: body),
+    );
+  }
+
+  /// Enables the widget inspector and taps the center of the widget at [key].
+  Future<void> _inspect(WidgetTester tester, Key key) async {
+    await tester.tap(find.byIcon(Icons.format_shapes));
+    await tester.pump();
+
+    final box = tester.renderObject(find.byKey(key)) as RenderBox;
+    final center = (box.localToGlobal(Offset.zero) & box.size).center;
+    await tester.tapAt(center);
+    await tester.pump();
+  }
+
+  group('Text section', () {
+    testWidgets(
+      'Given a Text widget, '
+      'When inspected, '
+      'Then the font size row is shown',
+      (tester) async {
+        await tester.pumpWidget(_buildApp(
+          const Center(
+            child: Text('Hello',
+                key: _widgetKey, style: TextStyle(fontSize: 18.0)),
+          ),
+        ));
+        await _inspect(tester, _widgetKey);
+
+        expect(find.text('font size'), findsOneWidget);
+        expect(find.text('18.0'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Given a Text widget, '
+      'When inspected, '
+      'Then the decoration section is not shown',
+      (tester) async {
+        await tester.pumpWidget(_buildApp(
+          const Center(child: Text('Hello', key: _widgetKey)),
+        ));
+        await _inspect(tester, _widgetKey);
+
+        expect(find.text('border radius (LTRB)'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'Given a SelectableText widget, '
+      'When inspected, '
+      'Then the font size row is shown',
+      (tester) async {
+        await tester.pumpWidget(_buildApp(
+          const Center(
+            child: SelectableText(
+              'Selectable',
+              key: _widgetKey,
+              style: TextStyle(fontSize: 22.0),
+            ),
+          ),
+        ));
+        await _inspect(tester, _widgetKey);
+
+        expect(find.text('font size'), findsOneWidget);
+        expect(find.text('22.0'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Given a SelectableText widget, '
+      'When inspected, '
+      'Then the decoration section is not shown',
+      (tester) async {
+        await tester.pumpWidget(_buildApp(
+          const Center(
+            child: SelectableText('Selectable', key: _widgetKey),
+          ),
+        ));
+        await _inspect(tester, _widgetKey);
+
+        expect(find.text('border radius (LTRB)'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'Given a decorated Container, '
+      'When inspected, '
+      'Then the color row is shown and the font size row is not',
+      (tester) async {
+        await tester.pumpWidget(_buildApp(
+          Center(
+            child: Container(
+              key: _widgetKey,
+              width: 100,
+              height: 100,
+              decoration: const BoxDecoration(color: Colors.red),
+            ),
+          ),
+        ));
+        await _inspect(tester, _widgetKey);
+
+        expect(find.text('color'), findsOneWidget);
+        expect(find.text('font size'), findsNothing);
+      },
+    );
+  });
+}

--- a/test/src/widgets/inspector/box_info_test.dart
+++ b/test/src/widgets/inspector/box_info_test.dart
@@ -1,0 +1,376 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:inspector/src/widgets/inspector/box_info.dart';
+
+const _parentKey = ValueKey('parent');
+const _childKey = ValueKey('child');
+const _largeKey = ValueKey('large');
+const _smallKey = ValueKey('small');
+const _foregroundKey = ValueKey('foreground');
+const _backgroundKey = ValueKey('background');
+
+void main() {
+  testWidgets(
+    'given a single box, '
+    'when calling fromHitTestResults, '
+    'then that box becomes the target',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SizedBox(key: _parentKey, width: 100, height: 100),
+        ),
+      );
+
+      final box = tester.renderObject(find.byKey(_parentKey)) as RenderBox;
+      final info = BoxInfo.fromHitTestResults([box]);
+
+      expect(info.targetRenderBox, same(box));
+    },
+  );
+
+  testWidgets(
+    'given nested boxes with different sizes, '
+    'when calling fromHitTestResults, '
+    'then the smallest child is the target',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(
+            child: SizedBox(
+              key: _parentKey,
+              width: 200,
+              height: 200,
+              child: Center(
+                child: SizedBox(key: _childKey, width: 50, height: 50),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final parent = tester.renderObject(find.byKey(_parentKey)) as RenderBox;
+      final child = tester.renderObject(find.byKey(_childKey)) as RenderBox;
+
+      // Simulate the parent-first order produced by _collectAt
+      final info = BoxInfo.fromHitTestResults([parent, child]);
+
+      expect(info.targetRenderBox, same(child));
+    },
+  );
+
+  testWidgets(
+    'given sibling boxes with different areas, '
+    'when calling fromHitTestResults, '
+    'then the smallest area wins regardless of list order',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Stack(
+            children: [
+              SizedBox(key: _largeKey, width: 100, height: 100),
+              SizedBox(key: _smallKey, width: 30, height: 30),
+            ],
+          ),
+        ),
+      );
+
+      final large = tester.renderObject(find.byKey(_largeKey)) as RenderBox;
+      final small = tester.renderObject(find.byKey(_smallKey)) as RenderBox;
+
+      // large first
+      expect(BoxInfo.fromHitTestResults([large, small]).targetRenderBox,
+          same(small));
+      // small first – result must be the same
+      expect(BoxInfo.fromHitTestResults([small, large]).targetRenderBox,
+          same(small));
+    },
+  );
+
+  testWidgets(
+    'given boxes with equal area, '
+    'when calling fromHitTestResults, '
+    'then the deepest box in the tree wins',
+    (tester) async {
+      // Both boxes are 100×100, but _childKey is nested inside _parentKey.
+      // _collectAt yields parent first → child comes last in the list.
+      // The child is a descendant of the parent, so it wins (more specific).
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(
+            child: SizedBox(
+              key: _parentKey,
+              width: 100,
+              height: 100,
+              child: SizedBox(key: _childKey, width: 100, height: 100),
+            ),
+          ),
+        ),
+      );
+
+      final parent = tester.renderObject(find.byKey(_parentKey)) as RenderBox;
+      final child = tester.renderObject(find.byKey(_childKey)) as RenderBox;
+
+      final info = BoxInfo.fromHitTestResults([parent, child]);
+
+      expect(info.targetRenderBox, same(child));
+    },
+  );
+
+  testWidgets(
+    'given Stack siblings with equal area, '
+    'when calling fromHitTestResults, '
+    'then the foreground sibling (first in list) wins over the background one',
+    (tester) async {
+      // _collectAt reverses children before recursing, so for a Stack with
+      // [background, foreground] the foreground is emitted first.
+      // When two siblings share the same area, neither is a descendant of the
+      // other → the first element (foreground) must be kept as the target.
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Stack(
+            children: [
+              SizedBox(key: _backgroundKey, width: 100, height: 100),
+              SizedBox(key: _foregroundKey, width: 100, height: 100),
+            ],
+          ),
+        ),
+      );
+
+      final foreground =
+          tester.renderObject(find.byKey(_foregroundKey)) as RenderBox;
+      final background =
+          tester.renderObject(find.byKey(_backgroundKey)) as RenderBox;
+
+      // Simulate the order produced by _collectAt (foreground first)
+      final info = BoxInfo.fromHitTestResults([foreground, background]);
+
+      expect(info.targetRenderBox, same(foreground),
+          reason:
+              'foreground sibling must win over background when areas are equal');
+    },
+  );
+
+  testWidgets(
+    'given Stack siblings with equal area listed background-first, '
+    'when calling fromHitTestResults, '
+    'then the first element in the list wins (list order is respected for siblings)',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Stack(
+            children: [
+              SizedBox(key: _backgroundKey, width: 100, height: 100),
+              SizedBox(key: _foregroundKey, width: 100, height: 100),
+            ],
+          ),
+        ),
+      );
+
+      final foreground =
+          tester.renderObject(find.byKey(_foregroundKey)) as RenderBox;
+      final background =
+          tester.renderObject(find.byKey(_backgroundKey)) as RenderBox;
+
+      // If caller passes background first, background wins – the contract is
+      // "first sibling wins", so the caller (_collectAt) is responsible for
+      // ordering (foreground first via children.reversed).
+      final info = BoxInfo.fromHitTestResults([background, foreground]);
+
+      expect(info.targetRenderBox, same(background),
+          reason: 'first sibling in list wins when areas are equal');
+    },
+  );
+
+  testWidgets(
+    'given multiple boxes, '
+    'when calling fromHitTestResults, '
+    'then hitTestPath preserves all boxes in original order',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(
+            child: SizedBox(
+              key: _parentKey,
+              width: 200,
+              height: 200,
+              child: Center(
+                child: SizedBox(key: _childKey, width: 50, height: 50),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final parent = tester.renderObject(find.byKey(_parentKey)) as RenderBox;
+      final child = tester.renderObject(find.byKey(_childKey)) as RenderBox;
+      final boxes = [parent, child];
+
+      final info = BoxInfo.fromHitTestResults(boxes);
+
+      expect(info.hitTestPath, equals(boxes));
+      expect(info.hitTestPath.length, 2);
+    },
+  );
+
+  testWidgets(
+    'given a box with an overlayOffset, '
+    'when accessing targetRectShifted, '
+    'then it returns targetRect shifted by the negative overlayOffset',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SizedBox(key: _parentKey, width: 100, height: 100),
+        ),
+      );
+
+      final box = tester.renderObject(find.byKey(_parentKey)) as RenderBox;
+      const offset = Offset(10, 20);
+
+      final info = BoxInfo.fromHitTestResults([box], overlayOffset: offset);
+
+      expect(info.targetRectShifted, equals(info.targetRect.shift(-offset)));
+    },
+  );
+
+  testWidgets(
+    'given nested boxes, '
+    'when calling fromHitTestResults with findContainer=false, '
+    'then containerRenderBox is null',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(
+            child: SizedBox(
+              key: _parentKey,
+              width: 200,
+              height: 200,
+              child: Center(
+                child: SizedBox(key: _childKey, width: 50, height: 50),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final parent = tester.renderObject(find.byKey(_parentKey)) as RenderBox;
+      final child = tester.renderObject(find.byKey(_childKey)) as RenderBox;
+
+      final info = BoxInfo.fromHitTestResults(
+        [parent, child],
+        findContainer: false, // default
+      );
+
+      expect(info.containerRenderBox, isNull);
+    },
+  );
+
+  testWidgets(
+    'given nested boxes with an ancestor larger than the target, '
+    'when calling fromHitTestResults with findContainer=true, '
+    'then containerRenderBox is set to the nearest larger ancestor',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(
+            child: SizedBox(
+              key: _parentKey,
+              width: 200,
+              height: 200,
+              child: Center(
+                child: SizedBox(key: _childKey, width: 50, height: 50),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final parent = tester.renderObject(find.byKey(_parentKey)) as RenderBox;
+      final child = tester.renderObject(find.byKey(_childKey)) as RenderBox;
+
+      final info = BoxInfo.fromHitTestResults(
+        [parent, child],
+        findContainer: true,
+      );
+
+      expect(info.targetRenderBox, same(child));
+      expect(info.containerRenderBox, same(parent));
+    },
+  );
+
+  testWidgets(
+    'given sibling boxes where the large box is not an ancestor of the small box, '
+    'when calling fromHitTestResults with findContainer=true, '
+    'then containerRenderBox stays null',
+    (tester) async {
+      // Large and small boxes are siblings in a Stack: large is NOT an ancestor of small.
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Stack(
+            children: [
+              SizedBox(key: _largeKey, width: 200, height: 200),
+              SizedBox(key: _smallKey, width: 30, height: 30),
+            ],
+          ),
+        ),
+      );
+
+      final large = tester.renderObject(find.byKey(_largeKey)) as RenderBox;
+      final small = tester.renderObject(find.byKey(_smallKey)) as RenderBox;
+
+      final info = BoxInfo.fromHitTestResults(
+        [large, small],
+        findContainer: true,
+      );
+
+      expect(info.targetRenderBox, same(small));
+      // large is a sibling, not an ancestor → cannot be a container
+      expect(info.containerRenderBox, isNull);
+    },
+  );
+
+  testWidgets(
+    'given boxes with multiple ancestors of different sizes, '
+    'when calling fromHitTestResults with findContainer=true, '
+    'then containerRenderBox is the smallest ancestor larger than the target',
+    (tester) async {
+      const _grandParentKey = ValueKey('grandparent');
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(
+            child: SizedBox(
+              key: _grandParentKey,
+              width: 300,
+              height: 300,
+              child: Center(
+                child: SizedBox(
+                  key: _parentKey,
+                  width: 150,
+                  height: 150,
+                  child: Center(
+                    child: SizedBox(key: _childKey, width: 50, height: 50),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final grandParent =
+          tester.renderObject(find.byKey(_grandParentKey)) as RenderBox;
+      final parent = tester.renderObject(find.byKey(_parentKey)) as RenderBox;
+      final child = tester.renderObject(find.byKey(_childKey)) as RenderBox;
+
+      final info = BoxInfo.fromHitTestResults(
+        [grandParent, parent, child],
+        findContainer: true,
+      );
+
+      expect(info.targetRenderBox, same(child));
+      // parent (150×150) is smaller than grandParent (300×300) but still larger
+      // than child (50×50) → parent should be picked as the nearest container.
+      expect(info.containerRenderBox, same(parent));
+    },
+  );
+}


### PR DESCRIPTION
- Improve selection accuracy.
- Improve border radius calculation and rendering accuracy (some `borderRadius` values cannot currently be displayed, such as those used by Ink widgets).
- Some unit test added to avoid future regression.
